### PR TITLE
chore: sync archetype versions to platform 0.9.0

### DIFF
--- a/kestros-project-archetype/pom.xml
+++ b/kestros-project-archetype/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.kestros.cms</groupId>
   <artifactId>kestros-project-archetype</artifactId>
-  <version>0.5.2</version>
+  <version>0.9.0</version>
 
   <name>Kestros Project Archetype</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-archetypes</artifactId>
-    <version>0.2.1</version>
+    <version>0.9.0</version>
 
     <name>Kestros CMS Archetypes</name>
     <description>Archetype for generating out a new project for Kestros.</description>


### PR DESCRIPTION
Bumps `kestros-archetypes` 0.2.1 → 0.9.0 and `kestros-project-archetype` 0.5.2 → 0.9.0 to match the platform version for the 0.9.0 release line.

Verified: `mvn install` on the module, `archetype:generate` of a test project, and a clean `mvn install` of the generated project.

Note: all `<module>` entries in the root pom are commented out, so the reactor builds nothing — the archetype module must be built directly (as the 0.5.x releases evidently were).