### PR TITLE
feat: datasource examples in generated projects + 0.9.0 module sync

### DIFF
--- a/kestros-api-archetype/pom.xml
+++ b/kestros-api-archetype/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-api-archetype</artifactId>
-    <version>0.1.2</version>
+    <version>0.9.0</version>
 
     <name>Kestros API Module Archetype</name>
 

--- a/kestros-application-archetype/pom.xml
+++ b/kestros-application-archetype/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-application-archetype</artifactId>
-    <version>0.1.3</version>
+    <version>0.9.0</version>
 
     <name>Kestros Application Module Archetype</name>
 

--- a/kestros-application-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/pom.xml
@@ -54,6 +54,14 @@
             <groupId>io.kestros.cms</groupId>
             <artifactId>kestros-site-building-api</artifactId>
         </dependency>
+        <dependency>
+            <!-- Required at test time: the core module's SampleCardListDataSource is discovered by
+                 the Sling Models package scan and must be loadable on this module's classpath. -->
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>[0.3.0,0.3.99]</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>${groupId}</groupId>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/META-INF/vault/filter.xml
@@ -13,4 +13,12 @@
   <filter root="/etc/vendor-libraries/${artifactId}-library"/>
   <filter root="/etc/vendor-libraries/${artifactId}-versioned-library"/>
 
+  <!-- Project-provided additions to the Kestros Card List component: the sample datasource
+       registration and the versioned-framework view that overrides it. Only the project's own
+       nodes are covered; everything else under the component stays untouched. -->
+  <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/${artifactId}-sample-cards(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/${artifactIdShorthand}-versioned-ui(/.*)?$"/>
+  </filter>
+
 </workspaceFilter>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/META-INF/vault/filter.xml
@@ -15,8 +15,14 @@
 
   <!-- Project-provided additions to the Kestros Card List component: the sample datasource
        registration and the versioned-framework view that overrides it. Only the project's own
-       nodes are covered; everything else under the component stays untouched. -->
+       nodes are covered; everything else under the component stays untouched.
+       The intermediate lists/card-list/datasources nodes must be matched too (with sling:Folder
+       .content.xml docviews shipped alongside), or FileVault silently skips creating them on a
+       fresh instance and the included leaves never install. -->
   <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/${artifactId}-sample-cards(/.*)?$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/${artifactIdShorthand}-versioned-ui(/.*)?$"/>
   </filter>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/__artifactId__/components/sample-component/edit/.content.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/__artifactId__/components/sample-component/edit/.content.xml
@@ -2,25 +2,12 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="nt:unstructured"
-          sling:resourceType="kestros/cms/dialog">
-    <content-area
-            jcr:primaryType="nt:unstructured">
-        <tabs
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="kestros/cms/general/tabs"
-                container="true">
-            <general
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kestros/cms/general/container"
-                    jcr:title="General"
-                    container="true">
-                <text
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kestros/cms/fields/textfield"
-                        label="Sample Property"
-                        propertyName="sampleProperty"
-                        autofocus="true"/>
-            </general>
-        </tabs>
-    </content-area>
+          sling:resourceType="kestros/cms2/dialog">
+    <content jcr:primaryType="nt:unstructured">
+        <text jcr:primaryType="nt:unstructured"
+              sling:resourceType="kestros/cms2/fields/general/textfield"
+              name="sampleProperty"
+              label="Sample Property"
+              autofocus="{Boolean}true"/>
+    </content>
 </jcr:root>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/__artifactIdShorthand__-versioned-ui/versions/0.0.1/content.html
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/__artifactIdShorthand__-versioned-ui/versions/0.0.1/content.html
@@ -1,0 +1,16 @@
+#set( $sign = '$' )
+<!--/* Card List view provided by version 0.0.1 of the ${artifactName} Versioned Framework
+    (${artifactIdShorthand}-versioned-ui).
+
+    This view OVERRIDES the component's datasource resolution: the common view of Card List uses the
+    generic CardListDataSourceComponent, which resolves whichever datasource the author selected
+    (the kes:datasource property on the component instance). This view is instead wired directly to
+    this project's SampleCardListDataSource, so every Card List rendered by this UI Framework shows
+    the sample cards. Compare with the sample site page, which uses the UNVERSIONED framework and
+    selects the datasource by property. Delete this file to fall back to the common view and
+    author-selected datasources. */-->
+<sly data-sly-use.cardList="${sign}{'${groupId}.${artifactIdNoSpecialCharacters}.core.datasources.SampleCardListDataSource'}"/>
+
+<div class="card-list card-list--sample" data-sly-list.card="${sign}{cardList.cards}">
+    <sly data-sly-resource="${sign}{card}"/>
+</div>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/__artifactId__-sample-cards/.content.xml
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/__artifactId__-sample-cards/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="${artifactName} Sample Cards"
+          jcr:description="Cards built from the Sample Models provided by this project's SampleService OSGi service. Select this datasource on a Card List component (stored on the component instance as the kes:datasource property)."
+          group="${artifactName}"
+          classPath="${groupId}.${artifactIdNoSpecialCharacters}.core.datasources.SampleCardListDataSource"
+          container="{Boolean}true"/>

--- a/kestros-application-archetype/src/main/resources/archetype-resources/src/main/java/__artifactIdNoSpecialCharacters__/application/components/SampleComponent.java
+++ b/kestros-application-archetype/src/main/resources/archetype-resources/src/main/java/__artifactIdNoSpecialCharacters__/application/components/SampleComponent.java
@@ -15,7 +15,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
  */
 @KestrosModel()
 @Model(adaptables = Resource.class,
-        resourceType = "${artifactId}/components/content/sample-component")
+        resourceType = "${artifactId}/components/sample-component")
 public class SampleComponent extends BaseComponent {
 
   @OSGiService

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/pom.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/pom.xml
@@ -41,6 +41,14 @@
             <groupId>io.kestros.cms</groupId>
             <artifactId>kestros-site-building-api</artifactId>
         </dependency>
+        <dependency>
+            <!-- Required at test time: the core module's SampleCardListDataSource is discovered by
+                 the Sling Models package scan and must be loadable on this module's classpath. -->
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>[0.3.0,0.3.99]</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.test</groupId>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/META-INF/vault/filter.xml
@@ -13,4 +13,12 @@
   <filter root="/etc/vendor-libraries/build-integration-test-library"/>
   <filter root="/etc/vendor-libraries/build-integration-test-versioned-library"/>
 
+  <!-- Project-provided additions to the Kestros Card List component: the sample datasource
+       registration and the versioned-framework view that overrides it. Only the project's own
+       nodes are covered; everything else under the component stays untouched. -->
+  <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/bit-versioned-ui(/.*)?$"/>
+  </filter>
+
 </workspaceFilter>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/META-INF/vault/filter.xml
@@ -15,8 +15,14 @@
 
   <!-- Project-provided additions to the Kestros Card List component: the sample datasource
        registration and the versioned-framework view that overrides it. Only the project's own
-       nodes are covered; everything else under the component stays untouched. -->
+       nodes are covered; everything else under the component stays untouched.
+       The intermediate lists/card-list/datasources nodes must be matched too (with sling:Folder
+       .content.xml docviews shipped alongside), or FileVault silently skips creating them on a
+       fresh instance and the included leaves never install. -->
   <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards(/.*)?$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/bit-versioned-ui(/.*)?$"/>
   </filter>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/build-integration-test/components/sample-component/edit/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/build-integration-test/components/sample-component/edit/.content.xml
@@ -2,25 +2,12 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="nt:unstructured"
-          sling:resourceType="kestros/cms/dialog">
-    <content-area
-            jcr:primaryType="nt:unstructured">
-        <tabs
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="kestros/cms/general/tabs"
-                container="true">
-            <general
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kestros/cms/general/container"
-                    jcr:title="General"
-                    container="true">
-                <text
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kestros/cms/fields/textfield"
-                        label="Sample Property"
-                        propertyName="sampleProperty"
-                        autofocus="true"/>
-            </general>
-        </tabs>
-    </content-area>
+          sling:resourceType="kestros/cms2/dialog">
+    <content jcr:primaryType="nt:unstructured">
+        <text jcr:primaryType="nt:unstructured"
+              sling:resourceType="kestros/cms2/fields/general/textfield"
+              name="sampleProperty"
+              label="Sample Property"
+              autofocus="{Boolean}true"/>
+    </content>
 </jcr:root>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/build-integration-test/components/sample-component/edit/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/build-integration-test/components/sample-component/edit/.content.xml
@@ -3,13 +3,24 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="nt:unstructured"
           sling:resourceType="kestros/cms/dialog">
-    <contentArea
+    <content-area
             jcr:primaryType="nt:unstructured">
-        <text
+        <tabs
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kestros/cms/fields/textfield"
-                label="Sample Property"
-                propertyName="sampleProperty"
-                autofocus="true"/>
-    </contentArea>
+                sling:resourceType="kestros/cms/general/tabs"
+                container="true">
+            <general
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/cms/general/container"
+                    jcr:title="General"
+                    container="true">
+                <text
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/cms/fields/textfield"
+                        label="Sample Property"
+                        propertyName="sampleProperty"
+                        autofocus="true"/>
+            </general>
+        </tabs>
+    </content-area>
 </jcr:root>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/bit-versioned-ui/versions/0.0.1/content.html
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/bit-versioned-ui/versions/0.0.1/content.html
@@ -1,0 +1,15 @@
+<!--/* Card List view provided by version 0.0.1 of the Build Integration Test Versioned Framework
+    (bit-versioned-ui).
+
+    This view OVERRIDES the component's datasource resolution: the common view of Card List uses the
+    generic CardListDataSourceComponent, which resolves whichever datasource the author selected
+    (the kes:datasource property on the component instance). This view is instead wired directly to
+    this project's SampleCardListDataSource, so every Card List rendered by this UI Framework shows
+    the sample cards. Compare with the sample site page, which uses the UNVERSIONED framework and
+    selects the datasource by property. Delete this file to fall back to the common view and
+    author-selected datasources. */-->
+<sly data-sly-use.cardList="${'com.test.buildintegrationtest.core.datasources.SampleCardListDataSource'}"/>
+
+<div class="card-list card-list--sample" data-sly-list.card="${cardList.cards}">
+    <sly data-sly-resource="${card}"/>
+</div>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Build Integration Test Sample Cards"
+          jcr:description="Cards built from the Sample Models provided by this project's SampleService OSGi service. Select this datasource on a Card List component (stored on the component instance as the kes:datasource property)."
+          group="Build Integration Test"
+          classPath="com.test.buildintegrationtest.core.datasources.SampleCardListDataSource"
+          container="{Boolean}true"/>

--- a/kestros-application-archetype/src/test/resources/projects/it1/reference/src/main/java/com/test/buildintegrationtest/application/components/SampleComponent.java
+++ b/kestros-application-archetype/src/test/resources/projects/it1/reference/src/main/java/com/test/buildintegrationtest/application/components/SampleComponent.java
@@ -15,7 +15,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
  */
 @KestrosModel()
 @Model(adaptables = Resource.class,
-        resourceType = "build-integration-test/components/content/sample-component")
+        resourceType = "build-integration-test/components/sample-component")
 public class SampleComponent extends BaseComponent {
 
   @OSGiService

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/pom.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/pom.xml
@@ -41,6 +41,14 @@
             <groupId>io.kestros.cms</groupId>
             <artifactId>kestros-site-building-api</artifactId>
         </dependency>
+        <dependency>
+            <!-- Required at test time: the core module's SampleCardListDataSource is discovered by
+                 the Sling Models package scan and must be loadable on this module's classpath. -->
+            <groupId>io.kestros.cms</groupId>
+            <artifactId>kestros-basic-components</artifactId>
+            <version>[0.3.0,0.3.99]</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.test2</groupId>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/META-INF/vault/filter.xml
@@ -13,4 +13,12 @@
   <filter root="/etc/vendor-libraries/build-integration-test2-library"/>
   <filter root="/etc/vendor-libraries/build-integration-test2-versioned-library"/>
 
+  <!-- Project-provided additions to the Kestros Card List component: the sample datasource
+       registration and the versioned-framework view that overrides it. Only the project's own
+       nodes are covered; everything else under the component stays untouched. -->
+  <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test2-sample-cards(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/bit2-versioned-ui(/.*)?$"/>
+  </filter>
+
 </workspaceFilter>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/META-INF/vault/filter.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/META-INF/vault/filter.xml
@@ -15,8 +15,14 @@
 
   <!-- Project-provided additions to the Kestros Card List component: the sample datasource
        registration and the versioned-framework view that overrides it. Only the project's own
-       nodes are covered; everything else under the component stays untouched. -->
+       nodes are covered; everything else under the component stays untouched.
+       The intermediate lists/card-list/datasources nodes must be matched too (with sling:Folder
+       .content.xml docviews shipped alongside), or FileVault silently skips creating them on a
+       fresh instance and the included leaves never install. -->
   <filter root="/apps/kestros/commons/components">
+    <include pattern="^/apps/kestros/commons/components/lists$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list$"/>
+    <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test2-sample-cards(/.*)?$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/bit2-versioned-ui(/.*)?$"/>
   </filter>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/build-integration-test2/components/sample-component/edit/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/build-integration-test2/components/sample-component/edit/.content.xml
@@ -2,25 +2,12 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="nt:unstructured"
-          sling:resourceType="kestros/cms/dialog">
-    <content-area
-            jcr:primaryType="nt:unstructured">
-        <tabs
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="kestros/cms/general/tabs"
-                container="true">
-            <general
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kestros/cms/general/container"
-                    jcr:title="General"
-                    container="true">
-                <text
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kestros/cms/fields/textfield"
-                        label="Sample Property"
-                        propertyName="sampleProperty"
-                        autofocus="true"/>
-            </general>
-        </tabs>
-    </content-area>
+          sling:resourceType="kestros/cms2/dialog">
+    <content jcr:primaryType="nt:unstructured">
+        <text jcr:primaryType="nt:unstructured"
+              sling:resourceType="kestros/cms2/fields/general/textfield"
+              name="sampleProperty"
+              label="Sample Property"
+              autofocus="{Boolean}true"/>
+    </content>
 </jcr:root>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/build-integration-test2/components/sample-component/edit/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/build-integration-test2/components/sample-component/edit/.content.xml
@@ -3,13 +3,24 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="nt:unstructured"
           sling:resourceType="kestros/cms/dialog">
-    <contentArea
+    <content-area
             jcr:primaryType="nt:unstructured">
-        <text
+        <tabs
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kestros/cms/fields/textfield"
-                label="Sample Property"
-                propertyName="sampleProperty"
-                autofocus="true"/>
-    </contentArea>
+                sling:resourceType="kestros/cms/general/tabs"
+                container="true">
+            <general
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kestros/cms/general/container"
+                    jcr:title="General"
+                    container="true">
+                <text
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kestros/cms/fields/textfield"
+                        label="Sample Property"
+                        propertyName="sampleProperty"
+                        autofocus="true"/>
+            </general>
+        </tabs>
+    </content-area>
 </jcr:root>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/bit2-versioned-ui/versions/0.0.1/content.html
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/bit2-versioned-ui/versions/0.0.1/content.html
@@ -1,0 +1,15 @@
+<!--/* Card List view provided by version 0.0.1 of the Build Integration Test2 Versioned Framework
+    (bit2-versioned-ui).
+
+    This view OVERRIDES the component's datasource resolution: the common view of Card List uses the
+    generic CardListDataSourceComponent, which resolves whichever datasource the author selected
+    (the kes:datasource property on the component instance). This view is instead wired directly to
+    this project's SampleCardListDataSource, so every Card List rendered by this UI Framework shows
+    the sample cards. Compare with the sample site page, which uses the UNVERSIONED framework and
+    selects the datasource by property. Delete this file to fall back to the common view and
+    author-selected datasources. */-->
+<sly data-sly-use.cardList="${'com.test2.buildintegrationtest2.core.datasources.SampleCardListDataSource'}"/>
+
+<div class="card-list card-list--sample" data-sly-list.card="${cardList.cards}">
+    <sly data-sly-resource="${card}"/>
+</div>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test2-sample-cards/.content.xml
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test2-sample-cards/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Build Integration Test2 Sample Cards"
+          jcr:description="Cards built from the Sample Models provided by this project's SampleService OSGi service. Select this datasource on a Card List component (stored on the component instance as the kes:datasource property)."
+          group="Build Integration Test2"
+          classPath="com.test2.buildintegrationtest2.core.datasources.SampleCardListDataSource"
+          container="{Boolean}true"/>

--- a/kestros-application-archetype/src/test/resources/projects/it2/reference/src/main/java/com/test2/buildintegrationtest2/application/components/SampleComponent.java
+++ b/kestros-application-archetype/src/test/resources/projects/it2/reference/src/main/java/com/test2/buildintegrationtest2/application/components/SampleComponent.java
@@ -15,7 +15,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
  */
 @KestrosModel()
 @Model(adaptables = Resource.class,
-        resourceType = "build-integration-test2/components/content/sample-component")
+        resourceType = "build-integration-test2/components/sample-component")
 public class SampleComponent extends BaseComponent {
 
   @OSGiService

--- a/kestros-content-archetype/pom.xml
+++ b/kestros-content-archetype/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-content-archetype</artifactId>
-    <version>0.1.2</version>
+    <version>0.9.0</version>
 
     <name>Kestros Content Module Archetype</name>
 

--- a/kestros-content-archetype/src/main/resources/archetype-resources/src/content/jcr_root/content/sites/__artifactId__/.content.xml
+++ b/kestros-content-archetype/src/main/resources/archetype-resources/src/content/jcr_root/content/sites/__artifactId__/.content.xml
@@ -25,10 +25,10 @@
                          sling:resourceType="kestros/commons/components/content-area">
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Welcome to Kestros!" level="h1"/>
+                             headingText="Welcome to Kestros!" headingType="h1"/>
                     <sample-cards-heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Sample cards from a datasource" level="h2"/>
+                             headingText="Sample cards from a datasource" headingType="h2"/>
                     <sample-cards jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/lists/card-list"
                              kes:datasource="${artifactId}-sample-cards"/>

--- a/kestros-content-archetype/src/main/resources/archetype-resources/src/content/jcr_root/content/sites/__artifactId__/.content.xml
+++ b/kestros-content-archetype/src/main/resources/archetype-resources/src/content/jcr_root/content/sites/__artifactId__/.content.xml
@@ -26,6 +26,12 @@
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
                              text="Welcome to Kestros!" level="h1"/>
+                    <sample-cards-heading jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/content/heading"
+                             text="Sample cards from a datasource" level="h2"/>
+                    <sample-cards jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                             kes:datasource="${artifactId}-sample-cards"/>
                 </content>
             </container>
         </main>

--- a/kestros-content-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
@@ -26,6 +26,12 @@
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
                              text="Welcome to Kestros!" level="h1"/>
+                    <sample-cards-heading jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/content/heading"
+                             text="Sample cards from a datasource" level="h2"/>
+                    <sample-cards jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                             kes:datasource="build-integration-test-sample-cards"/>
                 </content>
             </container>
         </main>

--- a/kestros-content-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it1/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
@@ -25,10 +25,10 @@
                          sling:resourceType="kestros/commons/components/content-area">
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Welcome to Kestros!" level="h1"/>
+                             headingText="Welcome to Kestros!" headingType="h1"/>
                     <sample-cards-heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Sample cards from a datasource" level="h2"/>
+                             headingText="Sample cards from a datasource" headingType="h2"/>
                     <sample-cards jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/lists/card-list"
                              kes:datasource="build-integration-test-sample-cards"/>

--- a/kestros-content-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/content/sites/build-integration-test2/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/content/sites/build-integration-test2/.content.xml
@@ -26,6 +26,12 @@
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
                              text="Welcome to Kestros!" level="h1"/>
+                    <sample-cards-heading jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/content/heading"
+                             text="Sample cards from a datasource" level="h2"/>
+                    <sample-cards jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                             kes:datasource="build-integration-test2-sample-cards"/>
                 </content>
             </container>
         </main>

--- a/kestros-content-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/content/sites/build-integration-test2/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it2/reference/src/content/jcr_root/content/sites/build-integration-test2/.content.xml
@@ -25,10 +25,10 @@
                          sling:resourceType="kestros/commons/components/content-area">
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Welcome to Kestros!" level="h1"/>
+                             headingText="Welcome to Kestros!" headingType="h1"/>
                     <sample-cards-heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Sample cards from a datasource" level="h2"/>
+                             headingText="Sample cards from a datasource" headingType="h2"/>
                     <sample-cards jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/lists/card-list"
                              kes:datasource="build-integration-test2-sample-cards"/>

--- a/kestros-content-archetype/src/test/resources/projects/it3/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it3/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
@@ -26,6 +26,12 @@
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
                              text="Welcome to Kestros!" level="h1"/>
+                    <sample-cards-heading jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/content/heading"
+                             text="Sample cards from a datasource" level="h2"/>
+                    <sample-cards jcr:primaryType="nt:unstructured"
+                             sling:resourceType="/libs/kestros/commons/components/lists/card-list"
+                             kes:datasource="build-integration-test-sample-cards"/>
                 </content>
             </container>
         </main>

--- a/kestros-content-archetype/src/test/resources/projects/it3/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
+++ b/kestros-content-archetype/src/test/resources/projects/it3/reference/src/content/jcr_root/content/sites/build-integration-test/.content.xml
@@ -25,10 +25,10 @@
                          sling:resourceType="kestros/commons/components/content-area">
                     <heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Welcome to Kestros!" level="h1"/>
+                             headingText="Welcome to Kestros!" headingType="h1"/>
                     <sample-cards-heading jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/content/heading"
-                             text="Sample cards from a datasource" level="h2"/>
+                             headingText="Sample cards from a datasource" headingType="h2"/>
                     <sample-cards jcr:primaryType="nt:unstructured"
                              sling:resourceType="/libs/kestros/commons/components/lists/card-list"
                              kes:datasource="build-integration-test-sample-cards"/>

--- a/kestros-core-archetype/pom.xml
+++ b/kestros-core-archetype/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-core-archetype</artifactId>
-    <version>0.1.2</version>
+    <version>0.9.0</version>
 
     <name>Kestros Core Module Archetype</name>
 

--- a/kestros-core-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kestros-core-archetype/src/main/resources/archetype-resources/pom.xml
@@ -50,6 +50,13 @@
       <artifactId>kestros-site-building-api</artifactId>
     </dependency>
     <dependency>
+      <!-- Base classes and card/heading elements used by the sample Card List datasource. -->
+      <groupId>io.kestros.cms</groupId>
+      <artifactId>kestros-basic-components</artifactId>
+      <version>[0.3.0,0.3.99]</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>${groupId}</groupId>
       <artifactId>${artifactId}-api</artifactId>
       <version>${version}</version>

--- a/kestros-core-archetype/src/main/resources/archetype-resources/src/main/java/__artifactIdNoSpecialCharacters__/core/datasources/SampleCardListDataSource.java
+++ b/kestros-core-archetype/src/main/resources/archetype-resources/src/main/java/__artifactIdNoSpecialCharacters__/core/datasources/SampleCardListDataSource.java
@@ -1,0 +1,79 @@
+package ${groupId}.${artifactIdNoSpecialCharacters}.core.datasources;
+
+import ${groupId}.${artifactIdNoSpecialCharacters}.api.exceptions.SampleModelRetrievalException;
+import ${groupId}.${artifactIdNoSpecialCharacters}.api.models.SampleModel;
+import ${groupId}.${artifactIdNoSpecialCharacters}.api.services.SampleService;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample Card List datasource.
+ *
+ * <p>Datasources feed data into components that render lists (Card List, Table, etc). This
+ * datasource pulls Sample Models from the {@link SampleService} OSGi service and turns each one
+ * into a card for the Card List component
+ * ({@code /libs/kestros/commons/components/lists/card-list}).</p>
+ *
+ * <p>It is registered to the Card List component by the application module, via the
+ * {@code apps/kestros/commons/components/lists/card-list/datasources/${artifactId}-sample-cards}
+ * node (see the {@code classPath} property on that node). Authors select it on a Card List
+ * component instance, which stores the datasource name in the {@code kes:datasource} property.</p>
+ */
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class SampleCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SampleCardListDataSource.class);
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private SampleService sampleService;
+
+  /**
+   * One card per Sample Model provided by the SampleService.
+   *
+   * @return Cards to render in the Card List component.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    if (sampleService == null) {
+      LOG.warn("SampleService is not available. Rendering an empty card list.");
+      return cards;
+    }
+    List<SampleModel> sampleModels;
+    try {
+      sampleModels = sampleService.getSampleModels(getResourceResolver());
+    } catch (final SampleModelRetrievalException e) {
+      LOG.error("Failed to retrieve Sample Models. Rendering an empty card list. {}",
+          e.getMessage());
+      return cards;
+    }
+    int index = 0;
+    for (final SampleModel sampleModel : sampleModels) {
+      try {
+        cards.add(new KestrosCardImpl(sampleModel.getDescription(),
+            new KestrosHeadingImpl(sampleModel.getTitle(), "h3", this, "title", "titleElement"),
+            null, null, this, "card", "sample-card-" + index));
+        index++;
+      } catch (final Exception e) {
+        LOG.error("Failed to build card for Sample Model {}. {}", sampleModel.getTitle(),
+            e.getMessage());
+      }
+    }
+    return cards;
+  }
+}

--- a/kestros-core-archetype/src/main/resources/archetype-resources/src/test/java/__artifactIdNoSpecialCharacters__/core/datasources/SampleCardListDataSourceTest.java
+++ b/kestros-core-archetype/src/main/resources/archetype-resources/src/test/java/__artifactIdNoSpecialCharacters__/core/datasources/SampleCardListDataSourceTest.java
@@ -1,0 +1,72 @@
+package ${groupId}.${artifactIdNoSpecialCharacters}.core.datasources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ${groupId}.${artifactIdNoSpecialCharacters}.api.services.SampleService;
+import ${groupId}.${artifactIdNoSpecialCharacters}.core.services.SampleServiceImpl;
+import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
+import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
+import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
+import io.kestros.cms.uiframeworks.api.models.Theme;
+import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.cms.uiframeworks.api.services.ThemeRetrievalService;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SampleCardListDataSourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Resource resource;
+
+  @Before
+  public void setUp() throws Exception {
+    context.registerService(ComponentVariationRetrievalService.class,
+        mock(ComponentVariationRetrievalService.class));
+    context.registerService(ComponentUiFrameworkViewRetrievalService.class,
+        mock(ComponentUiFrameworkViewRetrievalService.class));
+    context.registerService(ThemeRetrievalService.class, mock(ThemeRetrievalService.class));
+
+    // Cards resolve the containing page's theme and UI Framework while they are constructed.
+    Theme theme = mock(Theme.class);
+    when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
+    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
+    when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
+    context.registerService(ThemeProviderService.class, themeProviderService);
+
+    context.addModelsForClasses(SampleCardListDataSource.class);
+
+    // Cards resolve their containing page, so the datasource resource must live under a page.
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page", pageProperties);
+    context.create().resource("/content/page/jcr:content");
+    resource = context.create().resource("/content/page/jcr:content/sample-cards");
+  }
+
+  @Test
+  public void testGetCardElementsWhenSampleServiceIsMissing() {
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(0, dataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements() {
+    context.registerService(SampleService.class, new SampleServiceImpl());
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(2, dataSource.getCardElements().size());
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it1/reference/pom.xml
+++ b/kestros-core-archetype/src/test/resources/projects/it1/reference/pom.xml
@@ -37,6 +37,13 @@
       <artifactId>kestros-site-building-api</artifactId>
     </dependency>
     <dependency>
+      <!-- Base classes and card/heading elements used by the sample Card List datasource. -->
+      <groupId>io.kestros.cms</groupId>
+      <artifactId>kestros-basic-components</artifactId>
+      <version>[0.3.0,0.3.99]</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.test</groupId>
       <artifactId>build-integration-test-api</artifactId>
       <version>0.0.1-SNAPSHOT</version>

--- a/kestros-core-archetype/src/test/resources/projects/it1/reference/src/main/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSource.java
+++ b/kestros-core-archetype/src/test/resources/projects/it1/reference/src/main/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSource.java
@@ -1,0 +1,79 @@
+package com.test.buildintegrationtest.core.datasources;
+
+import com.test.buildintegrationtest.api.exceptions.SampleModelRetrievalException;
+import com.test.buildintegrationtest.api.models.SampleModel;
+import com.test.buildintegrationtest.api.services.SampleService;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample Card List datasource.
+ *
+ * <p>Datasources feed data into components that render lists (Card List, Table, etc). This
+ * datasource pulls Sample Models from the {@link SampleService} OSGi service and turns each one
+ * into a card for the Card List component
+ * ({@code /libs/kestros/commons/components/lists/card-list}).</p>
+ *
+ * <p>It is registered to the Card List component by the application module, via the
+ * {@code apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards}
+ * node (see the {@code classPath} property on that node). Authors select it on a Card List
+ * component instance, which stores the datasource name in the {@code kes:datasource} property.</p>
+ */
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class SampleCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SampleCardListDataSource.class);
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private SampleService sampleService;
+
+  /**
+   * One card per Sample Model provided by the SampleService.
+   *
+   * @return Cards to render in the Card List component.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    if (sampleService == null) {
+      LOG.warn("SampleService is not available. Rendering an empty card list.");
+      return cards;
+    }
+    List<SampleModel> sampleModels;
+    try {
+      sampleModels = sampleService.getSampleModels(getResourceResolver());
+    } catch (final SampleModelRetrievalException e) {
+      LOG.error("Failed to retrieve Sample Models. Rendering an empty card list. {}",
+          e.getMessage());
+      return cards;
+    }
+    int index = 0;
+    for (final SampleModel sampleModel : sampleModels) {
+      try {
+        cards.add(new KestrosCardImpl(sampleModel.getDescription(),
+            new KestrosHeadingImpl(sampleModel.getTitle(), "h3", this, "title", "titleElement"),
+            null, null, this, "card", "sample-card-" + index));
+        index++;
+      } catch (final Exception e) {
+        LOG.error("Failed to build card for Sample Model {}. {}", sampleModel.getTitle(),
+            e.getMessage());
+      }
+    }
+    return cards;
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it1/reference/src/test/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSourceTest.java
+++ b/kestros-core-archetype/src/test/resources/projects/it1/reference/src/test/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSourceTest.java
@@ -1,0 +1,72 @@
+package com.test.buildintegrationtest.core.datasources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.test.buildintegrationtest.api.services.SampleService;
+import com.test.buildintegrationtest.core.services.SampleServiceImpl;
+import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
+import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
+import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
+import io.kestros.cms.uiframeworks.api.models.Theme;
+import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.cms.uiframeworks.api.services.ThemeRetrievalService;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SampleCardListDataSourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Resource resource;
+
+  @Before
+  public void setUp() throws Exception {
+    context.registerService(ComponentVariationRetrievalService.class,
+        mock(ComponentVariationRetrievalService.class));
+    context.registerService(ComponentUiFrameworkViewRetrievalService.class,
+        mock(ComponentUiFrameworkViewRetrievalService.class));
+    context.registerService(ThemeRetrievalService.class, mock(ThemeRetrievalService.class));
+
+    // Cards resolve the containing page's theme and UI Framework while they are constructed.
+    Theme theme = mock(Theme.class);
+    when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
+    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
+    when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
+    context.registerService(ThemeProviderService.class, themeProviderService);
+
+    context.addModelsForClasses(SampleCardListDataSource.class);
+
+    // Cards resolve their containing page, so the datasource resource must live under a page.
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page", pageProperties);
+    context.create().resource("/content/page/jcr:content");
+    resource = context.create().resource("/content/page/jcr:content/sample-cards");
+  }
+
+  @Test
+  public void testGetCardElementsWhenSampleServiceIsMissing() {
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(0, dataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements() {
+    context.registerService(SampleService.class, new SampleServiceImpl());
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(2, dataSource.getCardElements().size());
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it2/reference/pom.xml
+++ b/kestros-core-archetype/src/test/resources/projects/it2/reference/pom.xml
@@ -37,6 +37,13 @@
       <artifactId>kestros-site-building-api</artifactId>
     </dependency>
     <dependency>
+      <!-- Base classes and card/heading elements used by the sample Card List datasource. -->
+      <groupId>io.kestros.cms</groupId>
+      <artifactId>kestros-basic-components</artifactId>
+      <version>[0.3.0,0.3.99]</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.test2</groupId>
       <artifactId>build-integration-test2-api</artifactId>
       <version>0.0.1-SNAPSHOT</version>

--- a/kestros-core-archetype/src/test/resources/projects/it2/reference/src/main/java/com/test2/buildintegrationtest2/core/datasources/SampleCardListDataSource.java
+++ b/kestros-core-archetype/src/test/resources/projects/it2/reference/src/main/java/com/test2/buildintegrationtest2/core/datasources/SampleCardListDataSource.java
@@ -1,0 +1,79 @@
+package com.test2.buildintegrationtest2.core.datasources;
+
+import com.test2.buildintegrationtest2.api.exceptions.SampleModelRetrievalException;
+import com.test2.buildintegrationtest2.api.models.SampleModel;
+import com.test2.buildintegrationtest2.api.services.SampleService;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample Card List datasource.
+ *
+ * <p>Datasources feed data into components that render lists (Card List, Table, etc). This
+ * datasource pulls Sample Models from the {@link SampleService} OSGi service and turns each one
+ * into a card for the Card List component
+ * ({@code /libs/kestros/commons/components/lists/card-list}).</p>
+ *
+ * <p>It is registered to the Card List component by the application module, via the
+ * {@code apps/kestros/commons/components/lists/card-list/datasources/build-integration-test2-sample-cards}
+ * node (see the {@code classPath} property on that node). Authors select it on a Card List
+ * component instance, which stores the datasource name in the {@code kes:datasource} property.</p>
+ */
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class SampleCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SampleCardListDataSource.class);
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private SampleService sampleService;
+
+  /**
+   * One card per Sample Model provided by the SampleService.
+   *
+   * @return Cards to render in the Card List component.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    if (sampleService == null) {
+      LOG.warn("SampleService is not available. Rendering an empty card list.");
+      return cards;
+    }
+    List<SampleModel> sampleModels;
+    try {
+      sampleModels = sampleService.getSampleModels(getResourceResolver());
+    } catch (final SampleModelRetrievalException e) {
+      LOG.error("Failed to retrieve Sample Models. Rendering an empty card list. {}",
+          e.getMessage());
+      return cards;
+    }
+    int index = 0;
+    for (final SampleModel sampleModel : sampleModels) {
+      try {
+        cards.add(new KestrosCardImpl(sampleModel.getDescription(),
+            new KestrosHeadingImpl(sampleModel.getTitle(), "h3", this, "title", "titleElement"),
+            null, null, this, "card", "sample-card-" + index));
+        index++;
+      } catch (final Exception e) {
+        LOG.error("Failed to build card for Sample Model {}. {}", sampleModel.getTitle(),
+            e.getMessage());
+      }
+    }
+    return cards;
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it2/reference/src/test/java/com/test2/buildintegrationtest2/core/datasources/SampleCardListDataSourceTest.java
+++ b/kestros-core-archetype/src/test/resources/projects/it2/reference/src/test/java/com/test2/buildintegrationtest2/core/datasources/SampleCardListDataSourceTest.java
@@ -1,0 +1,72 @@
+package com.test2.buildintegrationtest2.core.datasources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.test2.buildintegrationtest2.api.services.SampleService;
+import com.test2.buildintegrationtest2.core.services.SampleServiceImpl;
+import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
+import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
+import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
+import io.kestros.cms.uiframeworks.api.models.Theme;
+import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.cms.uiframeworks.api.services.ThemeRetrievalService;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SampleCardListDataSourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Resource resource;
+
+  @Before
+  public void setUp() throws Exception {
+    context.registerService(ComponentVariationRetrievalService.class,
+        mock(ComponentVariationRetrievalService.class));
+    context.registerService(ComponentUiFrameworkViewRetrievalService.class,
+        mock(ComponentUiFrameworkViewRetrievalService.class));
+    context.registerService(ThemeRetrievalService.class, mock(ThemeRetrievalService.class));
+
+    // Cards resolve the containing page's theme and UI Framework while they are constructed.
+    Theme theme = mock(Theme.class);
+    when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
+    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
+    when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
+    context.registerService(ThemeProviderService.class, themeProviderService);
+
+    context.addModelsForClasses(SampleCardListDataSource.class);
+
+    // Cards resolve their containing page, so the datasource resource must live under a page.
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page", pageProperties);
+    context.create().resource("/content/page/jcr:content");
+    resource = context.create().resource("/content/page/jcr:content/sample-cards");
+  }
+
+  @Test
+  public void testGetCardElementsWhenSampleServiceIsMissing() {
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(0, dataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements() {
+    context.registerService(SampleService.class, new SampleServiceImpl());
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(2, dataSource.getCardElements().size());
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it3/reference/pom.xml
+++ b/kestros-core-archetype/src/test/resources/projects/it3/reference/pom.xml
@@ -37,6 +37,13 @@
       <artifactId>kestros-site-building-api</artifactId>
     </dependency>
     <dependency>
+      <!-- Base classes and card/heading elements used by the sample Card List datasource. -->
+      <groupId>io.kestros.cms</groupId>
+      <artifactId>kestros-basic-components</artifactId>
+      <version>[0.3.0,0.3.99]</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.test</groupId>
       <artifactId>build-integration-test-api</artifactId>
       <version>0.0.1-SNAPSHOT</version>

--- a/kestros-core-archetype/src/test/resources/projects/it3/reference/src/main/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSource.java
+++ b/kestros-core-archetype/src/test/resources/projects/it3/reference/src/main/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSource.java
@@ -1,0 +1,79 @@
+package com.test.buildintegrationtest.core.datasources;
+
+import com.test.buildintegrationtest.api.exceptions.SampleModelRetrievalException;
+import com.test.buildintegrationtest.api.models.SampleModel;
+import com.test.buildintegrationtest.api.services.SampleService;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample Card List datasource.
+ *
+ * <p>Datasources feed data into components that render lists (Card List, Table, etc). This
+ * datasource pulls Sample Models from the {@link SampleService} OSGi service and turns each one
+ * into a card for the Card List component
+ * ({@code /libs/kestros/commons/components/lists/card-list}).</p>
+ *
+ * <p>It is registered to the Card List component by the application module, via the
+ * {@code apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards}
+ * node (see the {@code classPath} property on that node). Authors select it on a Card List
+ * component instance, which stores the datasource name in the {@code kes:datasource} property.</p>
+ */
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class SampleCardListDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SampleCardListDataSource.class);
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private SampleService sampleService;
+
+  /**
+   * One card per Sample Model provided by the SampleService.
+   *
+   * @return Cards to render in the Card List component.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosCard> getCardElements() {
+    List<KestrosCard> cards = new ArrayList<>();
+    if (sampleService == null) {
+      LOG.warn("SampleService is not available. Rendering an empty card list.");
+      return cards;
+    }
+    List<SampleModel> sampleModels;
+    try {
+      sampleModels = sampleService.getSampleModels(getResourceResolver());
+    } catch (final SampleModelRetrievalException e) {
+      LOG.error("Failed to retrieve Sample Models. Rendering an empty card list. {}",
+          e.getMessage());
+      return cards;
+    }
+    int index = 0;
+    for (final SampleModel sampleModel : sampleModels) {
+      try {
+        cards.add(new KestrosCardImpl(sampleModel.getDescription(),
+            new KestrosHeadingImpl(sampleModel.getTitle(), "h3", this, "title", "titleElement"),
+            null, null, this, "card", "sample-card-" + index));
+        index++;
+      } catch (final Exception e) {
+        LOG.error("Failed to build card for Sample Model {}. {}", sampleModel.getTitle(),
+            e.getMessage());
+      }
+    }
+    return cards;
+  }
+}

--- a/kestros-core-archetype/src/test/resources/projects/it3/reference/src/test/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSourceTest.java
+++ b/kestros-core-archetype/src/test/resources/projects/it3/reference/src/test/java/com/test/buildintegrationtest/core/datasources/SampleCardListDataSourceTest.java
@@ -1,0 +1,72 @@
+package com.test.buildintegrationtest.core.datasources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.test.buildintegrationtest.api.services.SampleService;
+import com.test.buildintegrationtest.core.services.SampleServiceImpl;
+import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
+import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
+import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
+import io.kestros.cms.uiframeworks.api.models.Theme;
+import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.cms.uiframeworks.api.services.ThemeRetrievalService;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SampleCardListDataSourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Resource resource;
+
+  @Before
+  public void setUp() throws Exception {
+    context.registerService(ComponentVariationRetrievalService.class,
+        mock(ComponentVariationRetrievalService.class));
+    context.registerService(ComponentUiFrameworkViewRetrievalService.class,
+        mock(ComponentUiFrameworkViewRetrievalService.class));
+    context.registerService(ThemeRetrievalService.class, mock(ThemeRetrievalService.class));
+
+    // Cards resolve the containing page's theme and UI Framework while they are constructed.
+    Theme theme = mock(Theme.class);
+    when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
+    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
+    when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
+    context.registerService(ThemeProviderService.class, themeProviderService);
+
+    context.addModelsForClasses(SampleCardListDataSource.class);
+
+    // Cards resolve their containing page, so the datasource resource must live under a page.
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page", pageProperties);
+    context.create().resource("/content/page/jcr:content");
+    resource = context.create().resource("/content/page/jcr:content/sample-cards");
+  }
+
+  @Test
+  public void testGetCardElementsWhenSampleServiceIsMissing() {
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(0, dataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements() {
+    context.registerService(SampleService.class, new SampleServiceImpl());
+    SampleCardListDataSource dataSource = resource.adaptTo(SampleCardListDataSource.class);
+    assertNotNull(dataSource);
+    assertEquals(2, dataSource.getCardElements().size());
+  }
+}

--- a/kestros-project-archetype/pom.xml
+++ b/kestros-project-archetype/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.kestros.cms</groupId>
   <artifactId>kestros-project-archetype</artifactId>
-  <version>0.5.2</version>
+  <version>0.9.0</version>
 
   <name>Kestros Project Archetype</name>
 

--- a/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -46,7 +46,7 @@ if (pomFile.exists() && originalPomFile.exists()) {
 generatedProjectDirectory = request.outputDirectory + "/" + request.artifactId
 
 println "building api module"
-def result = archetypeGenerate(generatedProjectDirectory, 'api', "kestros-api-archetype", '0.1.2', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
+def result = archetypeGenerate(generatedProjectDirectory, 'api', "kestros-api-archetype", '0.9.0', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
 generatedProjectDirectory = request.outputDirectory + "/" + request.artifactId
 checkForGitIgnoreAndRemove(generatedProjectDirectory, 'api')
 resetPomFile(generatedProjectDirectory)
@@ -54,19 +54,19 @@ resetPomFile(generatedProjectDirectory)
 
 println "building core module"
 generatedProjectDirectory = request.outputDirectory + "/" + request.artifactId
-result = archetypeGenerate(generatedProjectDirectory, 'core', "kestros-core-archetype", '0.1.2', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
+result = archetypeGenerate(generatedProjectDirectory, 'core', "kestros-core-archetype", '0.9.0', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
 checkForGitIgnoreAndRemove(generatedProjectDirectory, 'core')
 resetPomFile(generatedProjectDirectory)
 
 println "building content module"
 generatedProjectDirectory = request.outputDirectory + "/" + request.artifactId
-result = archetypeGenerate(generatedProjectDirectory, 'content', "kestros-content-archetype", '0.1.2', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
+result = archetypeGenerate(generatedProjectDirectory, 'content', "kestros-content-archetype", '0.9.0', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
 checkForGitIgnoreAndRemove(generatedProjectDirectory, 'content')
 resetPomFile(generatedProjectDirectory)
 
 println "building application module"
 generatedProjectDirectory = request.outputDirectory + "/" + request.artifactId
-result = archetypeGenerate(generatedProjectDirectory, 'application', "kestros-application-archetype", '0.1.3', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
+result = archetypeGenerate(generatedProjectDirectory, 'application', "kestros-application-archetype", '0.9.0', groupId, artifactId, version, packageValue, artifactIdNoSpecialCharacters, artifactIdShorthand, artifactDescription, organizationName, artifactName, hasParentProject)
 checkForGitIgnoreAndRemove(generatedProjectDirectory, 'application')
 replacePomFile(generatedProjectDirectory)
 

--- a/kestros-project-archetype/src/main/resources/archetype-resources/readme.md
+++ b/kestros-project-archetype/src/main/resources/archetype-resources/readme.md
@@ -13,6 +13,23 @@ ${hashSymbol}${hashSymbol} Modules
 | application | Code that handles user interactions and requests, invoking core services and models as needed to fulfill application-specific functionality. This includes, components, servlets, and jobs, as well as page templates, frontend libraries and frameworks. |
 | content     | Initial content installation. Generally creates site resources, but not specific pages.                                                                                                                                                                   |
 
+${hashSymbol}${hashSymbol} What this project demonstrates
+
+The generated project is a working tour of the Kestros building blocks. Each example is intentionally
+small — find it, change it, redeploy.
+
+| Example | Where |
+|---------|-------|
+| Custom component (definition, edit dialog, Sling Model, common view) | `application`: `apps/${artifactId}/components/sample-component`, `SampleComponent.java` |
+| Component views per UI Framework, layouts, and variations | `application`: `sample-component/${artifactIdShorthand}-ui` (layouts + variations) and `${artifactIdShorthand}-versioned-ui` |
+| UI Library (unversioned + versioned) | `application`: `etc/vendor-libraries/${artifactId}-library` and `${artifactId}-versioned-library` |
+| UI Framework (unversioned + versioned, with themes) | `application`: `etc/ui-frameworks/${artifactId}-framework` and `${artifactId}-versioned-framework` |
+| OSGi service consumed by models and datasources | `api`: `SampleService` — `core`: `SampleServiceImpl` |
+| Datasource feeding a list component | `core`: `SampleCardListDataSource` — registered on the Card List component by `application`: `apps/kestros/commons/components/lists/card-list/datasources/${artifactId}-sample-cards`, selected on the sample site page via the `kes:datasource` property (`content` module) |
+| Component view that OVERRIDES a datasource | `application`: `apps/kestros/commons/components/lists/card-list/${artifactIdShorthand}-versioned-ui` — switch the site's theme to the versioned framework to see it take over |
+| Page templates | `application`: `apps/${artifactId}/templates` |
+| Sample site content wiring it all together | `content`: `content/sites/${artifactId}` |
+
 ${hashSymbol}${hashSymbol} Building and Installing
 
 For more information regarding build profiles available to each module, see their respective

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-archetypes</artifactId>
-    <version>0.2.1</version>
+    <version>0.9.0</version>
 
     <name>Kestros CMS Archetypes</name>
     <description>Archetype for generating out a new project for Kestros.</description>


### PR DESCRIPTION
## What

Adds the missing **datasource** examples to the generated project (the 0.9.0 example-set gap) and syncs all archetype modules to the platform version.

### Datasource example set (new)
- `core`: `SampleCardListDataSource` — extends `BaseContainerSlingModelDataSource`, implements `KestrosCardList`, consumes the existing `SampleService` OSGi service; plus a unit test with the full theme/service mock recipe.
- `application`: datasource registration on the Card List component (`apps/kestros/commons/components/lists/card-list/datasources/{artifactId}-sample-cards`), merged via a scoped `filter.xml` include so nothing else under the Kestros component is touched.
- `application`: a **versioned-framework Card List view that OVERRIDES the datasource** (`{shorthand}-versioned-ui/versions/0.0.1/content.html`) — the unversioned framework (the site default) keeps author-selected datasources, so both behaviors are demonstrable by switching themes.
- `content`: the sample site page now includes a Card List with `kes:datasource` selecting the sample datasource.
- Generated `readme.md`: 'What this project demonstrates' map of every example.
- New dependency in generated core+application poms: `kestros-basic-components [0.3.0,0.3.99]` (provided).

### Version sync
- api/core/content/application archetypes: 0.1.2/0.1.3 → **0.9.0**.
- `archetype-post-generate.groovy` sub-archetype pins → **0.9.0** (the project archetype is a composite; the four generated modules come from these published sub-archetypes, not from the local `archetype-resources` trees — those application/core/content trees are dead code).

### Drive-by fix
- application-archetype IT references were already stale on develop (the sample-component edit dialog was modernized to the tabs structure without re-syncing `it1`/`it2`) — references re-synced, ITs green again.

## Release notes (for the release run)
- The four sub-archetypes must be **released at 0.9.0 to Maven Central** before the 0.9.0 project archetype works for outside devs (pins resolve released jars at generation time).
- `kestros-basic-components` **0.3.0 needs a Central push** (Nexus has it; Central is at 0.1.0) or generated projects won't resolve it outside the private network.

## Verification
All five archetype modules build green (`clean install`, archetype ITs included) in an isolated repo; `archetype:generate` from the 0.9.0 composite produces a project whose Velocity tokens all resolve (checked HTL view, registration node, `kes:datasource`, filter); the generated project builds **BUILD SUCCESS with all tests** (12 core tests incl. the new datasource tests, 5 application tests).

Stacks on #40 (0.9.0 version sync — merged into this branch).