### PR TITLE
docs: require archetype PRs to update the published example list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What this changes
+
+<!-- One or two sentences. Detail belongs on the board card. -->
+
+## Board card
+
+<!-- kestros/<release>/<card>.md -->
+
+## Checklist
+
+- [ ] **If this PR adds, removes or renames an example the archetype ships, the list on
+      kestros.io has been updated in the same PR.**
+      It lives in `live/guide-project-structure.html` under *Reading the generated project*, in
+      `kestros-io-static-site`. That list is maintained by hand (Danny, 2026-07-31), so nothing
+      updates it for you, and a list that has gone stale is worse than no list because readers
+      trust it.
+- [ ] Generated projects still build.
+- [ ] The archetype integration tests pass, and their reference projects were regenerated if the
+      template changed.
+- [ ] No AI attribution anywhere in the commits, the branch name or this description.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,10 @@
 
 ## Checklist
 
-- [ ] **If this PR adds, removes or renames an example the archetype ships, the list on
-      kestros.io has been updated in the same PR.**
+- [ ] **If this PR adds, removes or renames an example the archetype ships, a PR updating the
+      list on kestros.io is open and linked below.**
+      It cannot be the same PR - the list lives in a different repository - so link it here and
+      say which merges first.
       It lives in `live/guide-project-structure.html` under *Reading the generated project*, in
       `kestros-io-static-site`. That list is maintained by hand (Danny, 2026-07-31), so nothing
       updates it for you, and a list that has gone stale is worse than no list because readers


### PR DESCRIPTION
The list of examples the archetype ships is now published on kestros.io and is maintained by hand, per your 2026-07-31 ruling. This adds the checklist item that keeps it true; the repo had no PR template, so this creates one.

Merge after kestros-io-static-site#2, which is the PR that publishes the list.

Board card: kestros/0.9.1/viewpath-docs-both-forms.md