### PR TITLE
fix: do not fetch a SNAPSHOT archetype from Central during generate (#124)

### DIFF
--- a/kestros-project-archetype/pom.xml
+++ b/kestros-project-archetype/pom.xml
@@ -58,6 +58,23 @@
     <archetype.version>3.2.1</archetype.version>
   </properties>
 
+  <!-- Test scope only. Nothing here reaches the generated project or the published archetype. -->
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- Parses archetype-post-generate.groovy so its logic can be tested directly. -->
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>3.0.21</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <extensions>
       <extension>
@@ -72,9 +89,36 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <source>1.11</source>
-          <target>1.11</target>
+          <!-- 11, not 1.11. There is no 1.11 and javac rejects it; the wrong value survived here
+               because until now the archetype lifecycle ran no compiler goal to read it. -->
+          <source>11</source>
+          <target>11</target>
         </configuration>
+        <!-- The maven-archetype lifecycle binds no test goals at all, so unit tests need both
+             of these declared by hand or src/test/java is silently never built or run. -->
+        <executions>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -95,20 +95,28 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
 //    println "organizationName: $organizationName"
 //    println "hasParentProject: $hasParentProject"
 
-    // update/download dependency using dependency plugin
-    def dependencyCommand = """mvn dependency:get -Dartifact=io.kestros.cms:$archetype:$archetypeVersion -Dtransative=false -U"""
-    println dependencyCommand
-    def dependencyResult = dependencyCommand.execute(null, new File(generatedProjectDirectory)).text
-
-    // print the result
-    println dependencyResult
-
-    // check that the dependency was downloaded
-    if (dependencyResult.contains("BUILD SUCCESS")) {
-        println "Dependency downloaded: io.kestros.cms:$archetype:$archetypeVersion"
+    // update/download dependency using dependency plugin, unless the version says not to.
+    // See dependencyGetCommandFor for which version is on which path.
+    def dependencyCommand = dependencyGetCommandFor(archetype, archetypeVersion)
+    if (dependencyCommand == null) {
+        println "Skipping dependency:get for SNAPSHOT archetype io.kestros.cms:$archetype:$archetypeVersion"
+        println "  A SNAPSHOT is not published to Maven Central. It has to be installed in the local"
+        println "  repository first - 'mvn install' on the archetype modules, in the order api, core,"
+        println "  content, application, project."
     } else {
-        println "Error downloading dependency: io.kestros.cms:$archetype:$archetypeVersion"
-        throw new Exception("Error downloading dependency: io.kestros.cms:$archetype:$archetypeVersion")
+        println dependencyCommand
+        def dependencyResult = dependencyCommand.execute(null, new File(generatedProjectDirectory)).text
+
+        // print the result
+        println dependencyResult
+
+        // check that the dependency was downloaded
+        if (dependencyResult.contains("BUILD SUCCESS")) {
+            println "Dependency downloaded: io.kestros.cms:$archetype:$archetypeVersion"
+        } else {
+            println "Error downloading dependency: io.kestros.cms:$archetype:$archetypeVersion"
+            throw new Exception("Error downloading dependency: io.kestros.cms:$archetype:$archetypeVersion")
+        }
     }
 
     println "Generating archetype: $archetype"
@@ -138,6 +146,11 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
         println "Archetype generated: $archetype"
     } else {
         println result
+        // For a SNAPSHOT that was never installed locally this is where the failure lands, and that
+        // is intended. Skipping dependency:get above does not make a missing SNAPSHOT resolvable; it
+        // only stops the script failing earlier for the wrong reason. The fix for a developer who
+        // sees this is 'mvn install' on the archetype modules, not another change here - a snapshot
+        // remote does not belong in a script that ships inside a released artifact.
         throw new Exception("Error generating archetype: $archetype")
     }
 
@@ -151,6 +164,25 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
     checkArchetypeWasBuilt(generatedProjectDirectory, directoryName)
     // do an ls -la command
     return result
+}
+
+// The command that fetches an archetype before it is generated, or null when there is nothing to
+// fetch. Two paths, and the archetype version alone decides which one you are on.
+//
+// RELEASED version - the path every end user is on. The archetype is on Maven Central, so it is
+// fetched up front and the caller fails loudly and early if it is not there, which is a clearer
+// error than whatever archetype:generate would report about it further down.
+//
+// -SNAPSHOT version - the developer path, and it must NOT fetch. A SNAPSHOT is never published to
+// Central, so dependency:get always failed and this script threw before it reached generation at
+// all. A SNAPSHOT has to be installed in the local repository first instead.
+//
+// Kept out of archetypeGenerate so the decision can be tested without launching Maven.
+def dependencyGetCommandFor(archetype, archetypeVersion) {
+    if (archetypeVersion != null && archetypeVersion.toString().endsWith("-SNAPSHOT")) {
+        return null
+    }
+    return """mvn dependency:get -Dartifact=io.kestros.cms:$archetype:$archetypeVersion -Dtransative=false -U"""
 }
 
 def checkArchetypeWasBuilt(generatedProjectDirectory, directoryName) {

--- a/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -92,16 +92,18 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
 //    println "organizationName: $organizationName"
 //    println "hasParentProject: $hasParentProject"
 
+    def mvn = mavenExecutable(System.getProperty("maven.home"), System.getProperty("os.name"))
+
     // update/download dependency using dependency plugin, unless the version says not to.
     // See dependencyGetCommandFor for which version is on which path.
-    def dependencyCommand = dependencyGetCommandFor(archetype, archetypeVersion)
+    def dependencyCommand = dependencyGetCommandFor(mvn, archetype, archetypeVersion)
     if (dependencyCommand == null) {
         println "Skipping dependency:get for SNAPSHOT archetype io.kestros.cms:$archetype:$archetypeVersion"
         println "  A SNAPSHOT is not published to Maven Central. It has to be installed in the local"
         println "  repository first - 'mvn install' on the archetype modules, in the order api, core,"
         println "  content, application, project."
     } else {
-        println dependencyCommand
+        println dependencyCommand.join(" ")
         def dependencyResult = dependencyCommand.execute(null, new File(generatedProjectDirectory)).text
 
         // print the result
@@ -121,7 +123,7 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
     // (artifactName / artifactDescription / organizationName) survive intact. The old
     // single-string form was tokenized on whitespace by String.execute(), which forced a
     // replaceAll("\\s","") strip that deleted spaces from the generated jcr:title values.
-    def command = ["mvn", "archetype:generate",
+    def command = [mvn, "archetype:generate",
                    "-DarchetypeGroupId=io.kestros.cms",
                    "-DarchetypeArtifactId=${archetype}".toString(),
                    "-DarchetypeVersion=${archetypeVersion}".toString(),
@@ -175,11 +177,38 @@ def archetypeGenerate(generatedProjectDirectory, directoryName, archetype, arche
 // all. A SNAPSHOT has to be installed in the local repository first instead.
 //
 // Kept out of archetypeGenerate so the decision can be tested without launching Maven.
-def dependencyGetCommandFor(archetype, archetypeVersion) {
+//
+// Each argument is its own list element, as with the generate command below, so a Maven path
+// containing a space is not torn in half by String.execute()'s whitespace tokenizing.
+def dependencyGetCommandFor(mavenExecutable, archetype, archetypeVersion) {
     if (archetypeVersion != null && archetypeVersion.toString().endsWith("-SNAPSHOT")) {
         return null
     }
-    return """mvn dependency:get -Dartifact=io.kestros.cms:$archetype:$archetypeVersion -Dtransative=false -U"""
+    return [mavenExecutable, "dependency:get",
+            "-Dartifact=io.kestros.cms:${archetype}:${archetypeVersion}".toString(),
+            "-Dtransative=false", "-U"]
+}
+
+// The Maven binary to fork with.
+//
+// `mvn` on PATH is not a safe assumption. This script runs inside a Maven JVM, but a process it
+// forks inherits the launcher's environment, and there are ordinary setups where that PATH holds
+// no mvn at all - a Jenkins Maven tool installation invokes it by absolute path, and so do the
+// Maven wrapper and most IDEs. When that happens the fork dies with "Cannot run program mvn"
+// before it can generate anything.
+//
+// Maven sets maven.home on its own JVM, so take the binary from there when it is there, and fall
+// back to PATH when it is not. Arguments rather than System.getProperty calls so the choice is
+// testable.
+def mavenExecutable(mavenHome, osName) {
+    if (mavenHome != null && !mavenHome.toString().trim().isEmpty()) {
+        def windows = osName != null && osName.toString().toLowerCase().contains("windows")
+        def candidate = new File(new File(mavenHome.toString(), "bin"), windows ? "mvn.cmd" : "mvn")
+        if (candidate.isFile()) {
+            return candidate.absolutePath
+        }
+    }
+    return "mvn"
 }
 
 def checkArchetypeWasBuilt(generatedProjectDirectory, directoryName) {

--- a/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kestros-project-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -34,10 +34,7 @@ if (gitIgnoreFile.exists()) {
 def pomFile = new File(generatedProjectDirectory + "/pom.xml")
 def originalPomFile = new File(generatedProjectDirectory + "/original-pom.xml")
 if (pomFile.exists()) {
-    // run cp pom.xml original-pom.xml
-    def command = "cp pom.xml original-pom.xml"
-    command.execute(null, new File(generatedProjectDirectory))
-
+    copyFile(pomFile, originalPomFile)
 }
 
 // make sure pom.xml and original-pom.xml exist
@@ -227,9 +224,23 @@ def resetPomFile(generatedProjectDirectory) {
     // copy original-pom.xml to pom.xml
     def originalPomFile = new File(generatedProjectDirectory + "/original-pom.xml")
     if (originalPomFile.exists()) {
-        // run cp original-pom.xml pom.xml
-        def command = "cp original-pom.xml pom.xml"
-        command.execute(null, new File(generatedProjectDirectory))
+        copyFile(originalPomFile, pomFile)
     }
+}
+
+// Copy a file and do not return until it is there.
+//
+// This used to shell out - "cp a b".execute(...) - and nothing ever waited on the process.
+// String.execute() returns as soon as the fork happens, so every caller carried on against a file
+// that might or might not exist yet. The observed failure was the existence check below the first
+// copy: when cp had not finished, it reported "pom.xml or original-pom.xml does not exist" and the
+// script returned before generating any module. resetPomFile had the same shape, which leaves
+// pom.xml missing for the next generation and for replacePomFile.
+//
+// A java.nio copy has finished when it returns, which removes both. It also drops a dependency on
+// a `cp` binary from a script that runs on whatever machine an end user generates a project on.
+def copyFile(source, target) {
+    java.nio.file.Files.copy(source.toPath(), target.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING)
 }
 

--- a/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
+++ b/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
@@ -2,15 +2,21 @@ package io.kestros.cms.archetype;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import groovy.lang.GroovyShell;
 import groovy.lang.Script;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Covers the released-versus-SNAPSHOT decision in archetype-post-generate.groovy, which ships
@@ -24,6 +30,9 @@ import org.junit.Test;
 public class ArchetypePostGenerateTest {
 
   private static final String SCRIPT = "/META-INF/archetype-post-generate.groovy";
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
 
   private Script script;
 
@@ -78,5 +87,61 @@ public class ArchetypePostGenerateTest {
     assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-api-archetype:null"
                  + " -Dtransative=false -U",
         String.valueOf(dependencyGetCommandFor("kestros-api-archetype", null)));
+  }
+
+  /**
+   * The script copied files by shelling out to `cp` and never waiting on the process, so the
+   * caller carried on against a file that might not exist yet. Every assertion below is made
+   * immediately on return, with no sleep and no retry — that is the whole point.
+   */
+  @Test
+  public void testCopyFileHasFinishedWhenItReturns() throws Exception {
+    final File source = folder.newFile("pom.xml");
+    Files.write(source.toPath(), "<project/>".getBytes(UTF_8));
+    final File target = new File(folder.getRoot(), "original-pom.xml");
+
+    script.invokeMethod("copyFile", new Object[]{source, target});
+
+    assertTrue("copyFile must not return before the target exists", target.exists());
+    assertEquals("<project/>", new String(Files.readAllBytes(target.toPath()), UTF_8));
+  }
+
+  @Test
+  public void testCopyFileOverwritesAnExistingTarget() throws Exception {
+    // resetPomFile copies onto a path the previous module's generation may have left behind.
+    final File source = folder.newFile("original-pom.xml");
+    Files.write(source.toPath(), "<project>new</project>".getBytes(UTF_8));
+    final File target = folder.newFile("pom.xml");
+    Files.write(target.toPath(), "<project>stale</project>".getBytes(UTF_8));
+
+    script.invokeMethod("copyFile", new Object[]{source, target});
+
+    assertEquals("<project>new</project>", new String(Files.readAllBytes(target.toPath()), UTF_8));
+  }
+
+  @Test
+  public void testResetPomFileRestoresPomFromOriginalBeforeItReturns() throws Exception {
+    // The generated project's pom.xml is rewritten by each submodule generation, so it is put back
+    // from original-pom.xml between them. The restore used to be an unwaited `cp`, so the next
+    // generation - and replacePomFile after it - could run against a pom.xml that was not there.
+    final File original = folder.newFile("original-pom.xml");
+    Files.write(original.toPath(), "<project>original</project>".getBytes(UTF_8));
+    final File pom = folder.newFile("pom.xml");
+    Files.write(pom.toPath(), "<project>with-modules</project>".getBytes(UTF_8));
+
+    script.invokeMethod("resetPomFile", new Object[]{folder.getRoot().getAbsolutePath()});
+
+    assertTrue("pom.xml must exist by the time resetPomFile returns", pom.exists());
+    assertEquals("<project>original</project>", new String(Files.readAllBytes(pom.toPath()), UTF_8));
+  }
+
+  @Test
+  public void testResetPomFileLeavesNoPomWhenThereIsNoOriginal() throws Exception {
+    final File pom = folder.newFile("pom.xml");
+    Files.write(pom.toPath(), "<project>with-modules</project>".getBytes(UTF_8));
+
+    script.invokeMethod("resetPomFile", new Object[]{folder.getRoot().getAbsolutePath()});
+
+    assertFalse("nothing to restore from, so pom.xml stays removed", pom.exists());
   }
 }

--- a/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
+++ b/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,15 +49,31 @@ public class ArchetypePostGenerateTest {
   }
 
   private Object dependencyGetCommandFor(final String archetype, final String archetypeVersion) {
+    return dependencyGetCommandFor("mvn", archetype, archetypeVersion);
+  }
+
+  private Object dependencyGetCommandFor(final String mavenExecutable, final String archetype,
+      final String archetypeVersion) {
     return script.invokeMethod("dependencyGetCommandFor",
-        new Object[]{archetype, archetypeVersion});
+        new Object[]{mavenExecutable, archetype, archetypeVersion});
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String joined(final Object command) {
+    // The command is a list so an executable path containing a space survives; joining it back
+    // keeps these assertions readable as the command line they produce.
+    return String.join(" ", (List<String>) command);
+  }
+
+  private Object mavenExecutable(final String mavenHome, final String osName) {
+    return script.invokeMethod("mavenExecutable", new Object[]{mavenHome, osName});
   }
 
   @Test
   public void testDependencyGetCommandForWhenVersionIsReleased() {
     assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-api-archetype:0.9.0"
                  + " -Dtransative=false -U",
-        String.valueOf(dependencyGetCommandFor("kestros-api-archetype", "0.9.0")));
+        joined(dependencyGetCommandFor("kestros-api-archetype", "0.9.0")));
   }
 
   @Test
@@ -79,14 +96,22 @@ public class ArchetypePostGenerateTest {
     // to carry the word elsewhere is still on Central and must still be fetched.
     assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-core-archetype:0.9.0"
                  + "-SNAPSHOT-rebuild -Dtransative=false -U",
-        String.valueOf(dependencyGetCommandFor("kestros-core-archetype", "0.9.0-SNAPSHOT-rebuild")));
+        joined(dependencyGetCommandFor("kestros-core-archetype", "0.9.0-SNAPSHOT-rebuild")));
   }
 
   @Test
   public void testDependencyGetCommandForWhenVersionIsNull() {
     assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-api-archetype:null"
                  + " -Dtransative=false -U",
-        String.valueOf(dependencyGetCommandFor("kestros-api-archetype", null)));
+        joined(dependencyGetCommandFor("kestros-api-archetype", null)));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testDependencyGetCommandForKeepsAMavenPathWithSpacesInOnePiece() {
+    final List<String> command = (List<String>) dependencyGetCommandFor(
+        "/opt/build tools/maven/bin/mvn", "kestros-api-archetype", "0.9.0");
+    assertEquals("/opt/build tools/maven/bin/mvn", command.get(0));
   }
 
   /**
@@ -143,5 +168,45 @@ public class ArchetypePostGenerateTest {
     script.invokeMethod("resetPomFile", new Object[]{folder.getRoot().getAbsolutePath()});
 
     assertFalse("nothing to restore from, so pom.xml stays removed", pom.exists());
+  }
+
+  /**
+   * The script forks Maven to generate each submodule. `mvn` is not always on the PATH a forked
+   * process inherits — a Jenkins Maven tool installation, the Maven wrapper and most IDEs all
+   * invoke it by absolute path — and the fork then dies with "Cannot run program mvn".
+   */
+  @Test
+  public void testMavenExecutableUsesTheBinaryFromMavenHome() throws Exception {
+    final File bin = folder.newFolder("maven", "bin");
+    final File mvn = new File(bin, "mvn");
+    assertTrue(mvn.createNewFile());
+
+    assertEquals(mvn.getAbsolutePath(),
+        mavenExecutable(bin.getParentFile().getAbsolutePath(), "Linux"));
+  }
+
+  @Test
+  public void testMavenExecutableUsesTheWindowsBinaryOnWindows() throws Exception {
+    final File bin = folder.newFolder("maven", "bin");
+    final File mvnCmd = new File(bin, "mvn.cmd");
+    assertTrue(mvnCmd.createNewFile());
+
+    assertEquals(mvnCmd.getAbsolutePath(),
+        mavenExecutable(bin.getParentFile().getAbsolutePath(), "Windows 10"));
+  }
+
+  @Test
+  public void testMavenExecutableFallsBackToThePathWhenMavenHomeIsUnset() {
+    // System.getProperty("maven.home") is set by Maven's own launcher, but the script must not
+    // break for anything that parses or runs it without one.
+    assertEquals("mvn", mavenExecutable(null, "Linux"));
+    assertEquals("mvn", mavenExecutable("  ", "Linux"));
+  }
+
+  @Test
+  public void testMavenExecutableFallsBackToThePathWhenMavenHomeHoldsNoBinary() throws Exception {
+    final File mavenHome = folder.newFolder("empty-maven");
+
+    assertEquals("mvn", mavenExecutable(mavenHome.getAbsolutePath(), "Linux"));
   }
 }

--- a/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
+++ b/kestros-project-archetype/src/test/java/io/kestros/cms/archetype/ArchetypePostGenerateTest.java
@@ -1,0 +1,82 @@
+package io.kestros.cms.archetype;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the released-versus-SNAPSHOT decision in archetype-post-generate.groovy, which ships
+ * inside the archetype and runs on an end user's machine.
+ *
+ * <p>A released archetype is on Maven Central and must still be fetched before generation. A
+ * -SNAPSHOT is never published there, so fetching it always fails and the script used to throw
+ * before it generated anything. The two paths must not be confused: applying the skip to a
+ * released version would break every real user to fix a developer path.
+ */
+public class ArchetypePostGenerateTest {
+
+  private static final String SCRIPT = "/META-INF/archetype-post-generate.groovy";
+
+  private Script script;
+
+  @Before
+  public void setUp() throws Exception {
+    // Parsed, not run. Running it would need the archetype plugin's `request` binding and would
+    // shell out to Maven; the decision under test is reachable without either.
+    final InputStream stream = getClass().getResourceAsStream(SCRIPT);
+    assertNotNull("archetype-post-generate.groovy is not on the classpath", stream);
+    try (InputStreamReader reader = new InputStreamReader(stream, UTF_8)) {
+      script = new GroovyShell().parse(reader, "archetype-post-generate.groovy");
+    }
+  }
+
+  private Object dependencyGetCommandFor(final String archetype, final String archetypeVersion) {
+    return script.invokeMethod("dependencyGetCommandFor",
+        new Object[]{archetype, archetypeVersion});
+  }
+
+  @Test
+  public void testDependencyGetCommandForWhenVersionIsReleased() {
+    assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-api-archetype:0.9.0"
+                 + " -Dtransative=false -U",
+        String.valueOf(dependencyGetCommandFor("kestros-api-archetype", "0.9.0")));
+  }
+
+  @Test
+  public void testDependencyGetCommandForWhenVersionIsSnapshot() {
+    assertNull(dependencyGetCommandFor("kestros-api-archetype", "0.9.1-SNAPSHOT"));
+  }
+
+  @Test
+  public void testDependencyGetCommandForWhenVersionIsSnapshotForEveryGeneratedModule() {
+    for (final String archetype : new String[]{"kestros-api-archetype", "kestros-core-archetype",
+        "kestros-content-archetype", "kestros-application-archetype"}) {
+      assertNull(archetype + " must not be fetched from Central as a SNAPSHOT",
+          dependencyGetCommandFor(archetype, "1.0.0-SNAPSHOT"));
+    }
+  }
+
+  @Test
+  public void testDependencyGetCommandForWhenVersionMerelyContainsSnapshot() {
+    // Only a version that ends in -SNAPSHOT is the developer path. A released version that happens
+    // to carry the word elsewhere is still on Central and must still be fetched.
+    assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-core-archetype:0.9.0"
+                 + "-SNAPSHOT-rebuild -Dtransative=false -U",
+        String.valueOf(dependencyGetCommandFor("kestros-core-archetype", "0.9.0-SNAPSHOT-rebuild")));
+  }
+
+  @Test
+  public void testDependencyGetCommandForWhenVersionIsNull() {
+    assertEquals("mvn dependency:get -Dartifact=io.kestros.cms:kestros-api-archetype:null"
+                 + " -Dtransative=false -U",
+        String.valueOf(dependencyGetCommandFor("kestros-api-archetype", null)));
+  }
+}

--- a/kestros-project-archetype/src/test/resources/projects/it1/reference/application/src/content/META-INF/vault/filter.xml
+++ b/kestros-project-archetype/src/test/resources/projects/it1/reference/application/src/content/META-INF/vault/filter.xml
@@ -25,6 +25,19 @@
     <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/datasources/build-integration-test-sample-cards(/.*)?$"/>
     <include pattern="^/apps/kestros/commons/components/lists/card-list/bit-versioned-ui(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/content$"/>
+    <include pattern="^/apps/kestros/commons/components/content/table$"/>
+    <include pattern="^/apps/kestros/commons/components/content/table/datasources$"/>
+    <include pattern="^/apps/kestros/commons/components/content/table/datasources/build-integration-test-sample-table(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/content/card$"/>
+    <include pattern="^/apps/kestros/commons/components/content/card/datasources$"/>
+    <include pattern="^/apps/kestros/commons/components/content/card/datasources/build-integration-test-sample-card(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/content/button$"/>
+    <include pattern="^/apps/kestros/commons/components/content/button/datasources$"/>
+    <include pattern="^/apps/kestros/commons/components/content/button/datasources/build-integration-test-sample-button(/.*)?$"/>
+    <include pattern="^/apps/kestros/commons/components/content/text$"/>
+    <include pattern="^/apps/kestros/commons/components/content/text/datasources$"/>
+    <include pattern="^/apps/kestros/commons/components/content/text/datasources/build-integration-test-sample-text(/.*)?$"/>
   </filter>
 
 </workspaceFilter>


### PR DESCRIPTION
Card #124.

`archetype-post-generate.groovy` ran `dependency:get` for every archetype and threw
when it did not report `BUILD SUCCESS`. A `-SNAPSHOT` is never published to Maven
Central, so that call always failed and the script died before it reached generation
at all — generating a project from a SNAPSHOT archetype was impossible.

## What changed

- The fetch now runs only for a **released** version, which is the path every end user
  is on. A `-SNAPSHOT` skips it and the script says which path it took, instead of
  leaving a developer to work it out from a stack trace.
- The decision lives in `dependencyGetCommandFor`, separate from `archetypeGenerate`,
  so it can be tested without launching Maven.
- The throw on a failed `archetype:generate` is deliberately **left alone** and now
  carries a comment saying why: skipping the fetch does not make a missing SNAPSHOT
  resolvable. The fix for a developer who hits it is `mvn install` on the archetype
  modules. A snapshot remote does not belong in a script that ships inside a released
  artifact.

Unit tests needed `maven-compiler-plugin:testCompile` and `maven-surefire-plugin:test`
declared by hand, because the `maven-archetype` lifecycle binds no test goals at all.
That exposed `source`/`target` `1.11`, which javac rejects; it is `11`, and it had
never been read before because no compiler goal ran in this module.

## The it1 integration test

`it1` was red on the base branch before this change. It is fixed here rather than on
its own card, per the ruling on #124. Card #641 keeps the record of what it was.

Three causes, each hiding the next:

- **Unwaited `cp`.** Both copies of the generated project's pom used
  `String.execute()`, which returns as soon as the process is forked. The existence
  check below the first one raced it, and on losing printed
  `pom.xml or original-pom.xml does not exist` and returned before generating any
  module. Both now use `java.nio.file.Files.copy`, which has finished when it returns.
- **`Cannot run program "mvn"`.** The script forks Maven per submodule and ran the
  literal `mvn`, which the fork only finds if the launcher's PATH carries it. A Jenkins
  Maven tool installation invokes Maven by absolute path, as do the wrapper and most
  IDEs. It now resolves the binary from `maven.home` and falls back to PATH. Only
  reachable once the first cause was fixed, which is why it had never been seen.
- **Stale reference.** `it1/reference/application/src/content/META-INF/vault/filter.xml`
  already carried the generated `.content.xml` nodes for the button, card, table and
  text sample datasources, but not the 13 vault filter entries covering them. The
  application archetype's own `it1`/`it2` references already have those exact lines;
  only this copy was missed. No test was weakened — the reference now matches content
  the archetype is meant to produce, and the artifact it generates from is the released
  0.9.0 on Maven Central (sha1 `69cbf33570ebd97f6e4ea6c11ce31756e234f949`, identical to
  the copy in the local repository).

## Tests

`ArchetypePostGenerateTest`, 14 cases: the released-versus-SNAPSHOT decision including
a version that merely *contains* `-SNAPSHOT`; that `copyFile` and `resetPomFile` have
finished when they return; and that the Maven executable comes from `maven.home` on
both Linux and Windows, falling back to PATH when there is none.

## Verification

Jenkins `verify-branch` #46 on this branch:

```
result: SUCCESS
tests:  17 passed, 0 failed, 0 skipped
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0 -- in io.kestros.cms.archetype.ArchetypePostGenerateTest
[INFO] Kestros Project Archetype .......................... SUCCESS [01:01 min]
```

Checkstyle, SpotBugs, RAT and coverage did not run — the gate skips them without
`PROFILES=strict`.
